### PR TITLE
feat: retrieve many resources of a stack with a single call

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,6 @@ jobs:
           access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
       - name: Get the outputs
         run: |
-          echo 'The outputs were ${{ steps.test.outputs }}'
           echo 'The endpoint was ${{ steps.test.outputs.endpoint }}'
           echo 'The dynamoDBCacheTableName was ${{ steps.test.outputs.dynamoDBCacheTableName }}'
       - name: Testing old pulumi outputs
@@ -34,4 +33,4 @@ jobs:
           resource: endpoint
           access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
       - name: Get the old style output
-        run: echo 'The output was ${{ steps.old-test.outputs.resource-output }}'
+        run: echo 'The old style output was ${{ steps.old-test.outputs.resource-output }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,11 @@ jobs:
             endpoint
             dynamoDBCacheTableName
           access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-      - name: Get the output
-        run: echo 'The 1nd output was ${{ steps.test.outputs.resource-outputs.endpoint }} and the 2nd output was ${{ steps.test.outputs.resource-outputs.dynamoDBCacheTableName }}'
+      - name: Get the outputs
+        run: |
+          echo 'The outputs were ${{ steps.test.outputs.resource-outputs }}'
+          echo 'The endpoint was ${{ steps.test.outputs.resource-outputs.endpoint }}'
+          echo 'The dynamoDBCacheTableName was ${{ steps.test.outputs.resource-outputs.dynamoDBCacheTableName }}'
       - name: Testing old pulumi outputs
         id: old-test
         uses: ./
@@ -30,5 +33,5 @@ jobs:
           stack: dev
           resource: endpoint
           access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-      - name: Get the output
+      - name: Get the old style output
         run: echo 'The output was ${{ steps.old-test.outputs.resource-output }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,5 @@
 on:
   workflow_dispatch:
-    branches: ['main']
 
 jobs:
   test:
@@ -16,7 +15,20 @@ jobs:
           organization: virtualfinland
           project: authentication-gw
           stack: dev
+          resources: |
+            endpoint
+            dynamoDBCacheTableName
+          access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+      - name: Get the output
+        run: echo 'The 1nd output was ${{ steps.test.outputs.resource-outputs.endpoint }} and the 2nd output was ${{ steps.test.outputs.resource-outputs.dynamoDBCacheTableName }}'
+      - name: Testing old pulumi outputs
+        id: old-test
+        uses: ./
+        with:
+          organization: virtualfinland
+          project: authentication-gw
+          stack: dev
           resource: endpoint
           access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
       - name: Get the output
-        run: echo 'The output was ${{ steps.test.outputs.resource-output }}'
+        run: echo 'The output was ${{ steps.old-test.outputs.resource-output }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,9 @@ jobs:
           access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
       - name: Get the outputs
         run: |
-          echo 'The outputs were ${{ steps.test.outputs.resource-outputs }}'
-          echo 'The endpoint was ${{ steps.test.outputs.resource-outputs.endpoint }}'
-          echo 'The dynamoDBCacheTableName was ${{ steps.test.outputs.resource-outputs.dynamoDBCacheTableName }}'
+          echo 'The outputs were ${{ steps.test.outputs }}'
+          echo 'The endpoint was ${{ steps.test.outputs.endpoint }}'
+          echo 'The dynamoDBCacheTableName was ${{ steps.test.outputs.dynamoDBCacheTableName }}'
       - name: Testing old pulumi outputs
         id: old-test
         uses: ./

--- a/README.md
+++ b/README.md
@@ -25,10 +25,18 @@ The name of the Pulumi resource whose output you wish to get. Conditions for thi
 
 ### `resources`
 
-List of names of the Pulumi resource whose output you wish to get. Conditions for this input:
+Line-end separated list of names of the Pulumi resource whose output you wish to get. Conditions for this input:
 
 - if `resource` is defined, this input is ignored
 - if both `resource` and `resources` are not defined, all available resources are returned.
+
+example yml-input:
+
+```yaml
+resources: |
+  endpointUrl
+  another
+```
 
 ### `access-token`
 
@@ -56,7 +64,9 @@ Get resources:
         organization: organization-name
         project: project-name
         stack: dev
-        resources: ['endpointUrl', 'another']
+        resources: |
+            endpointUrl
+            another
         access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 - name: Get the outputs
     run: |

--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ resources: |
 
 ## Outputs
 
-### `resource-outputs`
-
-Key-value object map of the requested resources.
+Outputs are dynamically named after the resource names defined in `resources` input. If `resource` input is defined, the output is named `resource-output`.
 
 ### `resource-output`
 
@@ -70,8 +68,8 @@ Get resources:
         access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 - name: Get the outputs
     run: |
-        echo 'The endpointUrl output was ${{ steps.action-id.outputs.resource-outputs.endpointUrl }}'
-        echo 'The another output was ${{ steps.action-id.outputs.resource-outputs.another }}'
+        echo 'The endpointUrl output was ${{ steps.action-id.outputs.endpointUrl }}'
+        echo 'The another output was ${{ steps.action-id.outputs.another }}'
 ```
 
 Get a single resource:
@@ -88,6 +86,6 @@ Get a single resource:
         access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 - name: Get the output
     run: |
-        echo 'The endpointUrl output was: ${{ steps.action-id.outputs.resource-outputs.endpointUrl }}'
+        echo 'The endpointUrl output was: ${{ steps.action-id.outputs.endpointUrl }}'
         echo 'Backwards compatibilite syntax for endpointUrl output: resource-output=${{ steps.action-id.outputs.resource-output }}'
 ```

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Get resources:
 ```yaml
 - name: Get Pulumi resource output
     id: action-id
-    uses: Virtual-Finland-Development/pulumi-outputs-action@v1.1
+    uses: Virtual-Finland-Development/pulumi-outputs-action@v1
     with:
         organization: organization-name
         project: project-name
@@ -69,7 +69,7 @@ Get a single resource:
 ```yaml
 - name: Get Pulumi resource output
     id: action-id
-    uses: Virtual-Finland-Development/pulumi-outputs-action@v1.1
+    uses: Virtual-Finland-Development/pulumi-outputs-action@v1
     with:
         organization: organization-name
         project: project-name

--- a/README.md
+++ b/README.md
@@ -18,7 +18,17 @@ Get output value from Pulumi application for defined inputs
 
 ### `resource`
 
-**Required** The name of the Pulumi resource whose output you wish to get.
+The name of the Pulumi resource whose output you wish to get. Conditions for this input:
+
+- if `resource` is defined, `resources` is ignored
+- if both `resource` and `resources` are not defined, all available resources are returned.
+
+### `resources`
+
+List of names of the Pulumi resource whose output you wish to get. Conditions for this input:
+
+- if `resource` is defined, this input is ignored
+- if both `resource` and `resources` are not defined, all available resources are returned.
 
 ### `access-token`
 
@@ -26,16 +36,40 @@ Get output value from Pulumi application for defined inputs
 
 ## Outputs
 
+### `resource-outputs`
+
+Key-value object map of the requested resources.
+
 ### `resource-output`
 
-The output for the requested resource.
+String output of the requested resource. Has a non-zero lenght value only if `resource` input is defined.
 
 ## Example usage
+
+Get resources:
 
 ```yaml
 - name: Get Pulumi resource output
     id: action-id
-    uses: Virtual-Finland-Development/pulumi-outputs-action@v1
+    uses: Virtual-Finland-Development/pulumi-outputs-action@v1.1
+    with:
+        organization: organization-name
+        project: project-name
+        stack: dev
+        resources: ['endpointUrl', 'another']
+        access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+- name: Get the outputs
+    run: |
+        echo 'The endpointUrl output was ${{ steps.action-id.outputs.resource-outputs.endpointUrl }}'
+        echo 'The another output was ${{ steps.action-id.outputs.resource-outputs.another }}'
+```
+
+Get a single resource:
+
+```yaml
+- name: Get Pulumi resource output
+    id: action-id
+    uses: Virtual-Finland-Development/pulumi-outputs-action@v1.1
     with:
         organization: organization-name
         project: project-name
@@ -43,5 +77,7 @@ The output for the requested resource.
         resource: endpointUrl
         access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 - name: Get the output
-    run: echo 'The output was ${{ steps.action-id.outputs.resource-output }}'
+    run: |
+        echo 'The endpointUrl output was: ${{ steps.action-id.outputs.resource-outputs.endpointUrl }}'
+        echo 'Backwards compatibilite syntax for endpointUrl output: resource-output=${{ steps.action-id.outputs.resource-output }}'
 ```

--- a/action.yml
+++ b/action.yml
@@ -21,8 +21,6 @@ inputs:
 outputs:
   resource-output:
     description: The requested resource output from Pulumi
-  resource-outputs:
-    description: Key-value pairs of the requested resource outputs from Pulumi
 runs:
   using: node16
   main: index.js

--- a/action.yml
+++ b/action.yml
@@ -11,13 +11,18 @@ inputs:
     required: true
   resource:
     description: Resource name
-    required: true
+    required: false
+  resources:
+    description: Resource names
+    required: false
   access-token:
     description: Pulumi access token
     required: true
 outputs:
   resource-output:
     description: The requested resource output from Pulumi
+  resource-outputs:
+    description: Key-value pairs of the requested resource outputs from Pulumi
 runs:
   using: node16
   main: index.js

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function pluckObjectKeys(obj, keys) {
     console.log(`Project stack: ${stack}`);
 
     const resourceName = core.getInput('resource');
-    const resourceNames = core.getInput('resources');
+    const resourceNames = core.getMultilineInput('resources');
     if (resourceName) {
       if (typeof resourceName !== 'string') {
         throw new Error('Requested resource must be a string!');

--- a/index.js
+++ b/index.js
@@ -80,18 +80,21 @@ function pluckObjectKeys(obj, keys) {
     //
     // Set outputs
     //
+    let resourceOutputs = null;
     if (resourceName) {
-      core.setOutput(
-        'resource-outputs',
-        pluckObjectKeys(resourceObject.outputs, [resourceName])
-      );
+      resourceOutputs = pluckObjectKeys(resourceObject.outputs, [resourceName]);
     } else if (resourceNames) {
-      core.setOutput(
-        'resource-outputs',
-        pluckObjectKeys(resourceObject.outputs, resourceNames)
-      );
+      resourceOutputs = pluckObjectKeys(resourceObject.outputs, resourceNames);
     } else {
-      core.setOutput('resource-outputs', resourceObject.outputs);
+      resourceOutputs = resourceObject.outputs;
+    }
+
+    // Static output
+    core.setOutput('resource-outputs', resourceOutputs);
+
+    // Dynamic outputs
+    for (const key in resourceOutputs) {
+      core.setOutput(key, resourceOutputs[key]);
     }
 
     // set 'resource-output' for backwards compatibility

--- a/index.js
+++ b/index.js
@@ -94,8 +94,8 @@ function pluckObjectKeys(obj, keys) {
       core.setOutput(key, resourceOutputs[key]);
     }
 
-    // set 'resource-output' for backwards compatibility
-    if (typeof resourceOutputs[resourceName] === 'undefined') {
+    // set 'resource-output' for backwards compatibility (if not already set)
+    if (typeof resourceOutputs['resource-output'] === 'undefined') {
       core.setOutput(
         'resource-output',
         resourceName ? resourceObject.outputs[resourceName] || '' : ''

--- a/index.js
+++ b/index.js
@@ -89,19 +89,18 @@ function pluckObjectKeys(obj, keys) {
       resourceOutputs = resourceObject.outputs;
     }
 
-    // Static output
-    core.setOutput('resource-outputs', resourceOutputs);
-
     // Dynamic outputs
     for (const key in resourceOutputs) {
       core.setOutput(key, resourceOutputs[key]);
     }
 
     // set 'resource-output' for backwards compatibility
-    core.setOutput(
-      'resource-output',
-      resourceName ? resourceObject.outputs[`${resourceName}`] || '' : ''
-    );
+    if (typeof resourceOutputs[resourceName] === 'undefined') {
+      core.setOutput(
+        'resource-output',
+        resourceName ? resourceObject.outputs[resourceName] || '' : ''
+      );
+    }
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi-outputs-action",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Get output values from Pulumi application(s) for defined inputs",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/Virtual-Finland-Development/pulumi-outputs-action/issues"
   },


### PR DESCRIPTION
# Version v1.1

Adds support for retrieving multiple pulumi resource outputs with a single call by adding a new input and an output:

Input: 

- `resources`: a list of resource names to retrieve

Output:

- a key-value map of retrieved pulumi outputs

## Backwards compatibility

If the `resource` input is defined, the new inputs are ignored and the flow works like it used to. 

For the `resource`-input there are now two different outputs for the value retrieval:

- `resource-output`: the v1.0 string output field
- `<resourceName>:<resourceValue>`: the v1.1 key-value map 

Better descriptions on the updated [readme file](https://github.com/Virtual-Finland-Development/pulumi-outputs-action/blob/feat/multiple-resources-outputting/README.md).
